### PR TITLE
feat: enhance notes card layout (#1)

### DIFF
--- a/client/src/pages/dashboard.jsx
+++ b/client/src/pages/dashboard.jsx
@@ -630,10 +630,10 @@ function Dashboard() {
                                 <div
                                     key={note._id}
                                     className="note-card"
+                                    data-color={note.color || "default"}
                                     style={{
                                         animationDelay: `${index * 0.05}s`,
                                         backgroundColor: NOTE_COLORS.find(c => c.id === (note.color || "default"))?.bg,
-                                        borderColor: NOTE_COLORS.find(c => c.id === (note.color || "default"))?.border
                                     }}
                                     onMouseEnter={() => setHoveredNote(note._id)}
                                     onMouseLeave={() => setHoveredNote(null)}
@@ -705,6 +705,10 @@ function Dashboard() {
                                         <div className="note-date">
                                             <HiOutlineClock />
                                             <span>{formatDate(note.createdAt)}</span>
+                                            <span className="note-reading-time">
+                                                <HiOutlineDocumentText />
+                                                {Math.max(1, Math.ceil(note.content.split(/\s+/).length / 200))} min read
+                                            </span>
                                         </div>
                                         <div className={`note-actions ${hoveredNote === note._id ? "visible" : ""}`}>
                                             <button onClick={(e) => openEditNote(note, e)} title="Edit">

--- a/client/src/styles/dashboard.css
+++ b/client/src/styles/dashboard.css
@@ -838,44 +838,88 @@ body {
 /* Notes Grid */
 .notes-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 16px;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 20px;
 }
 
 .notes-list {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 14px;
 }
 
 /* Note Card */
 .note-card {
     background: var(--bg-elevated);
     border: 1px solid var(--border);
+    border-left: 4px solid var(--accent);
     border-radius: var(--radius-lg);
-    padding: 20px;
+    padding: 22px 22px 18px;
     cursor: pointer;
-    transition: all 0.15s ease;
-    animation: fadeIn 0.3s ease backwards;
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    animation: cardFadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) backwards;
     position: relative;
+    overflow: hidden;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
 }
 
-@keyframes fadeIn {
+/* Color-specific accent stripes */
+.note-card[data-color="blue"] {
+    border-left-color: #60a5fa;
+}
+.note-card[data-color="green"] {
+    border-left-color: #4ade80;
+}
+.note-card[data-color="purple"] {
+    border-left-color: #a78bfa;
+}
+.note-card[data-color="orange"] {
+    border-left-color: #fb923c;
+}
+.note-card[data-color="default"] {
+    border-left-color: var(--accent);
+}
+
+/* Shimmer overlay on hover */
+.note-card::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+        90deg,
+        transparent,
+        rgba(255, 255, 255, 0.03),
+        transparent
+    );
+    transition: left 0.5s ease;
+    pointer-events: none;
+}
+
+.note-card:hover::after {
+    left: 100%;
+}
+
+@keyframes cardFadeIn {
     from {
         opacity: 0;
-        transform: translateY(10px);
+        transform: translateY(12px) scale(0.98);
     }
 
     to {
         opacity: 1;
-        transform: translateY(0);
+        transform: translateY(0) scale(1);
     }
 }
 
 .note-card:hover {
     border-color: var(--accent);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-lg);
+    border-left-color: var(--accent);
+    transform: translateY(-4px) scale(1.01);
+    box-shadow: var(--shadow-lg), 0 0 0 1px rgba(196, 165, 116, 0.1);
 }
 
 .note-header {
@@ -892,32 +936,61 @@ body {
 }
 
 .badge {
-    padding: 3px 10px;
-    border-radius: 4px;
-    font-size: 0.7rem;
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 0.68rem;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.04em;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
 }
 
 .badge.category {
     background: var(--accent-dim);
     color: var(--accent);
+    border-color: rgba(196, 165, 116, 0.2);
 }
 
 .badge.difficulty.easy {
     background: rgba(74, 222, 128, 0.1);
     color: var(--success);
+    border-color: rgba(74, 222, 128, 0.2);
+}
+
+.badge.difficulty.easy::before {
+    content: '●';
+    margin-right: 4px;
+    font-size: 0.5rem;
+    vertical-align: middle;
 }
 
 .badge.difficulty.medium {
     background: rgba(251, 191, 36, 0.1);
     color: var(--warning);
+    border-color: rgba(251, 191, 36, 0.2);
+}
+
+.badge.difficulty.medium::before {
+    content: '●';
+    margin-right: 4px;
+    font-size: 0.5rem;
+    vertical-align: middle;
 }
 
 .badge.difficulty.hard {
     background: rgba(248, 113, 113, 0.1);
     color: var(--danger);
+    border-color: rgba(248, 113, 113, 0.2);
+}
+
+.badge.difficulty.hard::before {
+    content: '●';
+    margin-right: 4px;
+    font-size: 0.5rem;
+    vertical-align: middle;
 }
 
 .favorite-btn {
@@ -945,32 +1018,43 @@ body {
 }
 
 .note-title {
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: 1.15rem;
+    font-weight: 700;
     color: var(--text-primary);
-    margin-bottom: 8px;
-    line-height: 1.3;
+    margin-bottom: 10px;
+    line-height: 1.35;
+    letter-spacing: -0.01em;
+    transition: color 0.2s ease;
+}
+
+.note-card:hover .note-title {
+    color: var(--accent);
 }
 
 .note-topic {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 6px;
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     color: var(--accent);
     margin-bottom: 12px;
+    padding: 3px 10px;
+    background: var(--accent-dim);
+    border-radius: 12px;
+    font-weight: 500;
 }
 
 .note-excerpt {
-    font-size: 0.9rem;
+    font-size: 0.875rem;
     color: var(--text-secondary);
-    line-height: 1.5;
+    line-height: 1.6;
     display: -webkit-box;
     -webkit-line-clamp: 3;
     line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
     margin-bottom: 16px;
+    letter-spacing: 0.01em;
 }
 
 .note-attachments {
@@ -1010,78 +1094,113 @@ body {
 .note-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: 8px;
     margin-bottom: 16px;
 }
 
 .tag {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 4px;
-    padding: 4px 10px;
+    padding: 4px 12px;
     background: var(--bg-secondary);
-    border-radius: 4px;
-    font-size: 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    font-size: 0.73rem;
     color: var(--text-secondary);
+    font-weight: 500;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tag:hover {
+    transform: translateY(-1px);
+}
+
+.tag svg {
+    font-size: 11px;
+    opacity: 0.6;
 }
 
 .tag.more {
     background: var(--accent-dim);
     color: var(--accent);
+    border-color: rgba(196, 165, 116, 0.2);
+    font-weight: 600;
 }
 
 .note-footer {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-top: 16px;
-    border-top: 1px solid var(--border);
+    padding-top: 14px;
+    border-top: 1px dashed var(--border);
+    margin-top: auto;
 }
 
 .note-date {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 6px;
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     color: var(--text-tertiary);
+    font-weight: 500;
+}
+
+.note-date svg {
+    font-size: 13px;
+    opacity: 0.7;
+}
+
+.note-reading-time {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    color: var(--text-tertiary);
+    margin-left: 12px;
+    padding-left: 12px;
+    border-left: 1px solid var(--border);
 }
 
 .note-actions {
     display: flex;
-    gap: 4px;
-    opacity: 0;
-    transition: opacity 0.15s ease;
+    gap: 6px;
+    opacity: 0.3;
+    transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.note-card:hover .note-actions,
 .note-card:hover .note-actions.visible {
     opacity: 1;
 }
 
 .note-actions button {
-    width: 28px;
-    height: 28px;
+    width: 30px;
+    height: 30px;
     display: flex;
     align-items: center;
     justify-content: center;
     background: var(--bg-secondary);
     border: 1px solid var(--border);
-    border-radius: var(--radius-md);
+    border-radius: 50%;
     color: var(--text-secondary);
     font-size: 14px;
     cursor: pointer;
-    transition: all 0.15s ease;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .note-actions button:hover {
     background: var(--accent);
     border-color: var(--accent);
     color: var(--bg-primary);
+    transform: scale(1.1);
 }
 
 .note-actions button.delete:hover {
     background: var(--danger);
     border-color: var(--danger);
     color: white;
+    transform: scale(1.1);
 }
 
 /* ===== Modal ===== */


### PR DESCRIPTION
- Add glassmorphism backdrop-filter for frosted glass effect
- Add colored left accent stripe per note color
- Make badges pill-shaped with dot indicators and borders
- Round tags with borders and hover micro-animations
- Improve typography: bolder titles, tighter letter-spacing
- Add shimmer overlay on card hover
- Dashed footer separator, circular action buttons with scale
- Add reading time indicator in note footer
- Always-visible action buttons (0.3 opacity → 1 on hover)
- Denser grid layout (280px min-width)

Closes #1